### PR TITLE
Fix lingering test after delete

### DIFF
--- a/AtomicWriter/AtomicWriter/MainWindow.xaml.cs
+++ b/AtomicWriter/AtomicWriter/MainWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace AtomicWriter
 
 		private void InitTestList()
 		{
-			if(_saveObject != null && _saveObject.Tests.Count > 0)
+			if(_saveObject != null)
 			{
 				TestsList.ItemsSource = _saveObject.Tests.Select(x => x.TestName);
 			}


### PR DESCRIPTION
Test list wasn't refreshing after deleting the last test because of the "&& _saveObject.Tests.Count > 0" portion of the check so I removed that portion. 

(also removing that part of the check doesn't cause errors or bugs) 👍 