### PR TITLE
Sarah

### DIFF
--- a/AtomicReader/AtomicReader/AtomicReader.csproj
+++ b/AtomicReader/AtomicReader/AtomicReader.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Objects\Instruction.cs" />
     <Compile Include="Objects\Locator.cs" />
     <Compile Include="Objects\SaveObject.cs" />
+    <Compile Include="Objects\SendKeyInstruction.cs" />
     <Compile Include="Objects\Test.cs" />
     <Compile Include="Objects\TypedTextInput.cs" />
     <Compile Include="Program.cs" />

--- a/AtomicReader/AtomicReader/Objects/Instruction.cs
+++ b/AtomicReader/AtomicReader/Objects/Instruction.cs
@@ -9,8 +9,9 @@
 		{
 			GoToUrl,
 			Click,
-            Type,
+            InputText,
             Assert,
+            SendKeys,
 		}
 	}
 }

--- a/AtomicReader/AtomicReader/Objects/SendKeyInstruction.cs
+++ b/AtomicReader/AtomicReader/Objects/SendKeyInstruction.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace AtomicReader.Objects
+{
+    public class SendKeyInstruction
+    {
+        public Locator Locator { get; set; }
+        public Keys Key { get; set; }
+
+        public static List<Keys> GetSendKeyTypes()
+        {
+            return new List<Keys>()
+            {
+                Keys.Enter,
+                Keys.Tab,
+            };
+        }
+    }
+}

--- a/AtomicReader/AtomicReader/TestRunner.cs
+++ b/AtomicReader/AtomicReader/TestRunner.cs
@@ -1,6 +1,8 @@
 ﻿using AtomicReader.Objects;
 using Newtonsoft.Json;
+using OpenQA.Selenium;
 using System;
+using System.Windows.Forms;
 
 namespace AtomicReader
 {
@@ -47,11 +49,14 @@ namespace AtomicReader
 					case Instruction.InstructionTypes.Click:
 						ExecuteClick(instruction.Payload);
 						break;
-					case Instruction.InstructionTypes.Type:
+					case Instruction.InstructionTypes.InputText:
 						ExecuteInput(instruction.Payload);
 						break;
                     case Instruction.InstructionTypes.Assert:
                         ExecuteAssertValue(instruction.Payload);
+                        break;
+                    case Instruction.InstructionTypes.SendKeys:
+                        ExecuteSendKeys(instruction.Payload);
                         break;
 					default:
 						Console.Write("InstructionType not Recognized");
@@ -92,6 +97,13 @@ namespace AtomicReader
 			var locator = typedTextInstruction.Locator;
 			_driver.WaitToInput(Locator.GetByLocator(locator.LocatorType, locator.Path), typedTextInstruction.Text);
 		}
+
+        private void ExecuteSendKeys(string payload)
+        {
+            var sendKeysInstruction = JsonConvert.DeserializeObject<SendKeyInstruction>(payload);
+            var locator = sendKeysInstruction.Locator;
+            _driver.SendKeys(Locator.GetByLocator(locator.LocatorType, locator.Path), sendKeysInstruction.Key.ToString());
+        }
 
         private void ExecuteAssertValue(string payload)
         {

--- a/AtomicReader/SeleniumBase/BaseDriver.cs
+++ b/AtomicReader/SeleniumBase/BaseDriver.cs
@@ -39,7 +39,7 @@ namespace SeleniumBase
 		{
 			WaitFor(location);
 			Input(location, text);
-		}
+        }
 
 		public void Input(By location, string text)
 		{
@@ -94,5 +94,20 @@ namespace SeleniumBase
 			var element = Driver.FindElement(location);
 			((IJavaScriptExecutor)Driver).ExecuteScript("arguments[0].scrollIntoView(true);", element);
 		}
+
+        public void SendKeys(By location, string keyString)
+        {
+            var key = Keys.Null;
+            if (keyString == "Return")
+            {
+                key = Keys.Return;
+            }
+            else if (keyString == "Tab")
+            {
+                key = Keys.Tab;
+            }
+
+            Driver.FindElement(location).SendKeys(key);
+        }
 	}
 }

--- a/AtomicReader/SeleniumBase/SeleniumBase.cs
+++ b/AtomicReader/SeleniumBase/SeleniumBase.cs
@@ -93,5 +93,10 @@ namespace SeleniumBase
 		{
 			return ((ITakesScreenshot)Driver).GetScreenshot();
 		}
-	}
+
+        public void SendKeys(By location, string keyString)
+        {
+            _baseDriver.SendKeys(location, keyString);
+        }
+    }
 }

--- a/AtomicWriter/AtomicWriter/AtomicWriter.csproj
+++ b/AtomicWriter/AtomicWriter/AtomicWriter.csproj
@@ -75,6 +75,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Objects\SendKeyInstruction.cs" />
     <Compile Include="ProjectSelection.xaml.cs">
       <DependentUpon>ProjectSelection.xaml</DependentUpon>
     </Compile>

--- a/AtomicWriter/AtomicWriter/EditTest.xaml.cs
+++ b/AtomicWriter/AtomicWriter/EditTest.xaml.cs
@@ -37,9 +37,11 @@ namespace AtomicWriter
             StackPanel instructionPanel = ((StackPanel)instructionTypeSelection.Parent);
 			var locatorSelection = ((ComboBox)instructionPanel.Children[1]);
             var textInput = ((TextBox)instructionPanel.Children[3]);
+            var keySelection = ((ComboBox)instructionPanel.Children[4]);
 
             var selectedInstruction = (Instruction.InstructionTypes)instructionTypeSelection.SelectedItem;
-            if (selectedInstruction == Instruction.InstructionTypes.Click || selectedInstruction == Instruction.InstructionTypes.Type || selectedInstruction == Instruction.InstructionTypes.Assert)
+            var displayLocatorSelection = selectedInstruction == Instruction.InstructionTypes.Click || selectedInstruction == Instruction.InstructionTypes.InputText || selectedInstruction == Instruction.InstructionTypes.Assert || selectedInstruction == Instruction.InstructionTypes.SendKeys;
+            if (displayLocatorSelection)
 			{
 				locatorSelection.Visibility = Visibility.Visible;
 			}
@@ -48,7 +50,7 @@ namespace AtomicWriter
 				locatorSelection.Visibility = Visibility.Collapsed;
 			}
 
-            if (selectedInstruction == Instruction.InstructionTypes.Type || selectedInstruction == Instruction.InstructionTypes.Assert)
+            if (selectedInstruction == Instruction.InstructionTypes.InputText || selectedInstruction == Instruction.InstructionTypes.Assert)
             {
                 textInput.Visibility = Visibility.Visible;
             }
@@ -57,6 +59,14 @@ namespace AtomicWriter
                 textInput.Visibility = Visibility.Collapsed;
             }
 
+            if (selectedInstruction == Instruction.InstructionTypes.SendKeys)
+            {
+                keySelection.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                keySelection.Visibility = Visibility.Collapsed;
+            }
         }
 
 		private void AddInstruction(Instruction instruction)
@@ -78,36 +88,48 @@ namespace AtomicWriter
 			var text = string.Empty;
 			Locator locator = null;
             var inputText = string.Empty;
+            System.Windows.Forms.Keys keySelection = 0;
+
 			if (instruction.InstructionType == Instruction.InstructionTypes.Click)
 			{
 				locator = JsonConvert.DeserializeObject<Locator>(instruction.Payload);
 				text = locator.Path;
 			}
-            else if (instruction.InstructionType == Instruction.InstructionTypes.Type)
+            else if (instruction.InstructionType == Instruction.InstructionTypes.InputText)
             {
                 var inputTextType = JsonConvert.DeserializeObject<TypedTextInput>(instruction.Payload);
                 locator = inputTextType.Locator;
-                text = inputTextType.Locator.Path;
+                text = locator.Path;
                 inputText = inputTextType.Text;
             } 
             else if (instruction.InstructionType == Instruction.InstructionTypes.Assert)
             {
                 var assert = JsonConvert.DeserializeObject<AssertValue>(instruction.Payload);
                 locator = assert.Locator;
-                text = assert.Locator.Path;
+                text = locator.Path;
                 inputText = assert.ExpectedValue;
+            }
+            else if (instruction.InstructionType == Instruction.InstructionTypes.SendKeys)
+            {
+                var sendKeyInstruction = JsonConvert.DeserializeObject<SendKeyInstruction>(instruction.Payload);
+                locator = sendKeyInstruction.Locator;
+                text = locator.Path;
+                keySelection = sendKeyInstruction.Key;
             }
             else 
             {
 				text = instruction.Payload;
 			}
 
-
-			var locatorSelection = new ComboBox()
+            var displayLocatorSelection = instruction.InstructionType == Instruction.InstructionTypes.Click ||
+                                          instruction.InstructionType == Instruction.InstructionTypes.Assert ||
+                                          instruction.InstructionType == Instruction.InstructionTypes.InputText ||
+                                          instruction.InstructionType == Instruction.InstructionTypes.SendKeys;
+            var locatorSelection = new ComboBox()
 			{
 				ItemsSource = Locator.GetLocatorTypes(),
-				Visibility = instruction.InstructionType == Instruction.InstructionTypes.Click || instruction.InstructionType == Instruction.InstructionTypes.Assert || instruction.InstructionType == Instruction.InstructionTypes.Type ? Visibility.Visible : Visibility.Collapsed,
-				SelectedItem = instruction.InstructionType == Instruction.InstructionTypes.Click || instruction.InstructionType == Instruction.InstructionTypes.Assert || instruction.InstructionType == Instruction.InstructionTypes.Type ? locator.LocatorType : Locator.LocatorTypes.Id,
+				Visibility = displayLocatorSelection ? Visibility.Visible : Visibility.Collapsed,
+				SelectedItem = displayLocatorSelection ? locator.LocatorType : Locator.LocatorTypes.Id,
 			};
 			instructionPanel.Children.Add(locatorSelection);
             instructionPanel.Children.Add(new TextBox()
@@ -117,12 +139,20 @@ namespace AtomicWriter
 
             var typedTextInput = new TextBox()
             {
-                Visibility = instruction.InstructionType == Instruction.InstructionTypes.Type || instruction.InstructionType == Instruction.InstructionTypes.Assert ? Visibility.Visible : Visibility.Collapsed,
+                Visibility = instruction.InstructionType == Instruction.InstructionTypes.InputText || instruction.InstructionType == Instruction.InstructionTypes.Assert ? Visibility.Visible : Visibility.Collapsed,
                 Text = inputText,
             };
             instructionPanel.Children.Add(typedTextInput);
 
-			var deleteInstructionButton = new Button()
+            var sendKeySelection = new ComboBox()
+            {
+                ItemsSource = SendKeyInstruction.GetSendKeyTypes(),
+                Visibility = instruction.InstructionType == Instruction.InstructionTypes.SendKeys ? Visibility.Visible : Visibility.Collapsed,
+                SelectedItem = keySelection,
+            };
+            instructionPanel.Children.Add(sendKeySelection);
+
+            var deleteInstructionButton = new Button()
 			{
 				Width = 50,
 				Content = new ContentControl()
@@ -160,7 +190,7 @@ namespace AtomicWriter
 						var locator = new Locator() { LocatorType = locatorType, Path = xpath };
 						payload = Newtonsoft.Json.JsonConvert.SerializeObject(locator);
 						break;
-                    case Instruction.InstructionTypes.Type:
+                    case Instruction.InstructionTypes.InputText:
                         xpath = ((TextBox)instructionPanel.Children[2]).Text;
                         var textInput = ((TextBox)instructionPanel.Children[3]).Text;
                         locatorType = (Locator.LocatorTypes)((ComboBox)(instructionPanel).Children[1]).SelectedValue;
@@ -183,6 +213,18 @@ namespace AtomicWriter
                             ExpectedValue = expectedValue,
                         };
                         payload = JsonConvert.SerializeObject(assertValue);
+                        break;
+                    case Instruction.InstructionTypes.SendKeys:
+                        xpath = ((TextBox)instructionPanel.Children[2]).Text;
+                        locatorType = (Locator.LocatorTypes)((ComboBox)(instructionPanel).Children[1]).SelectedValue;
+                        locator = new Locator() { LocatorType = locatorType, Path = xpath };
+                        var keySelection = (System.Windows.Forms.Keys)((ComboBox)(instructionPanel).Children[4]).SelectedValue;
+                        SendKeyInstruction sendKeyInstruction = new SendKeyInstruction()
+                        {
+                            Locator = locator,
+                            Key = keySelection,
+                        };
+                        payload = JsonConvert.SerializeObject(sendKeyInstruction);
                         break;
                     default:
 						MessageBox.Show("Error matching InstructionType");
@@ -239,6 +281,14 @@ namespace AtomicWriter
                 Visibility = Visibility.Collapsed
             };
             instructionPanel.Children.Add(textInput);
+
+            var keySelection = new ComboBox()
+            {
+                ItemsSource = SendKeyInstruction.GetSendKeyTypes(),
+                Visibility = Visibility.Collapsed,
+                SelectedItem = Locator.LocatorTypes.Id,
+            };
+            instructionPanel.Children.Add(keySelection);
 
 			var deleteInstructionButton = new Button()
 			{

--- a/AtomicWriter/AtomicWriter/Objects/Instruction.cs
+++ b/AtomicWriter/AtomicWriter/Objects/Instruction.cs
@@ -11,8 +11,9 @@ namespace AtomicWriter.Objects
 		{
 			GoToUrl,
 			Click,
-            Type,
+            InputText,
             Assert,
+            SendKeys,
 		}
 
 		public static List<InstructionTypes> GetInstructionTypes()
@@ -21,8 +22,9 @@ namespace AtomicWriter.Objects
 			{
 				InstructionTypes.GoToUrl,
 				InstructionTypes.Click,
-                InstructionTypes.Type,
+                InstructionTypes.InputText,
                 InstructionTypes.Assert,
+                InstructionTypes.SendKeys,
 			};
 		}
 	}

--- a/AtomicWriter/AtomicWriter/Objects/SendKeyInstruction.cs
+++ b/AtomicWriter/AtomicWriter/Objects/SendKeyInstruction.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace AtomicWriter.Objects
+{
+    public class SendKeyInstruction
+    {
+        public Locator Locator { get; set; }
+        public Keys Key { get; set; }
+
+        public static List<Keys> GetSendKeyTypes()
+        {
+            return new List<Keys>()
+            {
+                Keys.Enter,
+                Keys.Tab,
+            };
+        }
+    }
+}


### PR DESCRIPTION
It is literally impossible to either pass a Key object through functions (because it's static) and impossible to look up the Key object (because the selenium.key is just a static class, not an enum) which is why the SendKeys function in the BaseDriver.cs file has a if/else statement for finding the right Key. 

Also note you can't use Windows.Forms.Key in the selenium side of things. 